### PR TITLE
Refactor uniqFuncSequence to prevent mutation of input array

### DIFF
--- a/src/uniq-func-sequence.ts
+++ b/src/uniq-func-sequence.ts
@@ -1,7 +1,7 @@
 import { Engine, defaultEngine, randIntRange, sliceOut } from './utils'
 
 const uniqFuncSequence = <T>(arr: T[], engine: Engine = defaultEngine): () => (T | null) => {
-  let tempArr = arr
+  let tempArr = arr.slice()
 
   return () => {
     if (!tempArr.length) return null


### PR DESCRIPTION
## Summary
In this PR, I refactored `uniqFuncSequence` to avoid mutation of the input array. Instead of manipulating the original array, the function now creates a copy using Array.prototype.slice and performs operations on it.

## Motivation
Mutation of input can lead to unexpected side effects, especially when the function is used in different contexts or when the input is reused later in the code. This change is a step towards enhancing the predictability and purity of functions across our codebase.

## Discussion
While this PR focuses on `uniqFuncSequence`, I think it's worth discussing the potential benefits of avoiding mutation throughout the library. This approach could improve readability, predictability, and better adhere to functional programming principles.